### PR TITLE
Made changes to include few usecases and additional logging

### DIFF
--- a/CPVMigrate/Program.cs
+++ b/CPVMigrate/Program.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Xml;
 using System.Xml.Linq;
 using System.Xml.XPath;
 
@@ -12,6 +13,10 @@ namespace CPVMigrate
 {
     class Program
     {
+        private static int totalProjects = 0;
+
+        private static List<string> projects = new List<string>();
+
         static void Main(string[] args)
         {
             Console.WriteLine(" -- Central Package Version Migration Tool -- ");
@@ -24,45 +29,86 @@ namespace CPVMigrate
 
             foreach (var file in Directory.EnumerateFiles(rootFilePath, "*.csproj", SearchOption.AllDirectories))
             {
-                Console.WriteLine($"Processing {file}...");
-                foreach (var p in CollectPackages(file))
-                {
-                    packages.Add(p);
-                }
+                totalProjects++;
+                projects.Add(file);
 
-                RemovePackageVersions(file);
+                Console.WriteLine($"Processing {file}...");
+
+                var currentPackagesWithVersionAttribute = CollectPackages(file).ToList();
+
+                if (currentPackagesWithVersionAttribute.Count > 0)
+                {
+                    // Remove the packages from .csproj file only if it's collected in previous step.
+                    // Else, don't remove.  Just removing the packages without collecting the pacakges will be misleading.
+                    RemovePackageVersions(file); 
+                    foreach (var p in currentPackagesWithVersionAttribute)
+                    {
+                        packages.Add(p);
+                    }
+                }
             }
 
             WritePropsFile(packages, rootFilePath);
+
+            Console.WriteLine($"--------Processing Completed------------");
+            Console.WriteLine($"Total Projects Processed: {totalProjects}...");
+            Console.WriteLine($"Processed projects are: {string.Join(Environment.NewLine, projects)}...");
+            Console.ReadKey();
         }
 
         public static IEnumerable<NuGetPackage> CollectPackages(string csprojPath)
         {
             var packages = new List<NuGetPackage>();
-            XDocument projectXml;
             using (var stream = File.Open(csprojPath, FileMode.Open, FileAccess.Read, FileShare.Read))
             {
-                projectXml = XDocument.Load(stream, LoadOptions.SetLineInfo);
-                var packagesElements = projectXml.Root.XPathSelectElements("//PackageReference");
-                foreach (var element in packagesElements)
+                var projectXml = XDocument.Load(stream, LoadOptions.SetLineInfo);
+                var packagesElements = projectXml.Root.XPathSelectElements("//PackageReference").ToList();
+
+                if (packagesElements.Count.Equals(0))
+                {
+                    /* https://stackoverflow.com/a/84018408 */
+                    var namespaceManager = new XmlNamespaceManager(new NameTable());
+                    namespaceManager.AddNamespace("prefix", "http://schemas.microsoft.com/developer/msbuild/2003");
+                    packagesElements = projectXml.Root.XPathSelectElements("//prefix:PackageReference", namespaceManager).ToList();
+                }
+
+                // This is to make the tool idempotent. To avoid exception when we run the tool again on same project again.
+                var packagesWithVersion = packagesElements.Where(e => e.Attribute("Version") != null || e.Value != null).ToList();
+
+                foreach (var element in packagesWithVersion)
                 {
                     var p = new NuGetPackage()
                     {
                         Name = element.Attribute("Include").Value,
-                        Version = element.Attribute("Version").Value
+
+                        // element.Value is useful in case of Type-2 mentioned below. 
+                        Version = element.Attribute("Version")?.Value ?? element.Value
                     };
                     packages.Add(p);
                     Console.WriteLine($"   Processing {p.Name}");
                 }
+
+                Console.WriteLine($"   Found {packagesElements.Count} Packages in total.");
+                Console.WriteLine($"   Found {packagesWithVersion.Count} Packages with version attribute.");
                 Console.WriteLine($"   --------------------");
-                Console.WriteLine($"   Found {packagesElements.Count()} Packages Total.");
             }
             return packages;
         }
 
         public static void RemovePackageVersions(string csprojPath)
         {
-            File.WriteAllText(csprojPath, Regex.Replace(File.ReadAllText(csprojPath), "(PackageReference\\sInclude=\"[a-zA-Z0-9\\.]+\")(\\sVersion=\"[a-zA-Z0-9\\.-]+\")", "$1"), new UTF8Encoding(true));
+            //Type - 1
+            //< PackageReference Include = "Microsoft.ClearScript.V8.Native.win-x64" Version = "7.2.4-pdk" />
+
+            //Type - 2
+            //< PackageReference Include = "Microsoft.AspNet.Razor" >
+            //    < Version > 3.2.7 </ Version >
+            //</ PackageReference >
+
+            File.WriteAllText(csprojPath, Regex.Replace(File.ReadAllText(csprojPath), "(PackageReference\\s\\w.+)(\\sVersion=\"[a-zA-Z0-9\\.-]+\")", "$1"), new UTF8Encoding(true));
+
+            // This is for type 2. Doing a blind version removal currently. Should be improved. 
+            File.WriteAllText(csprojPath, Regex.Replace(File.ReadAllText(csprojPath), "(^|\\n).*<Version>\\w.+<\\/Version>.*\\n?", ""), new UTF8Encoding(true));
         }
 
         public static void WritePropsFile(IEnumerable<NuGetPackage> packages, string rootPath)
@@ -83,7 +129,6 @@ namespace CPVMigrate
 
             StreamWriter sw = new StreamWriter($"{rootPath}/Directory.packages.props");
             props.Save(sw, SaveOptions.None);
-            Console.WriteLine(sw);
         }
     }
 
@@ -100,7 +145,8 @@ namespace CPVMigrate
         public override bool Equals(object obj)
         {
             var other = obj as NuGetPackage;
-            if (other == null) {
+            if (other == null)
+            {
                 return false;
             }
             return Name == other.Name;


### PR DESCRIPTION
1. Made the tool idempotent - so that it doesn't error out if few projects of the parent directory are already migrated. 
2. XPathSelectElement was not selecting the packages from legacy projects (non-sdk).  So added a fix based on-https://stackoverflow.com/a/8401840
3. Package reference can be of two types. Modified existing regex to take care of Type-A.  Added one more regex to take care of Type-B. 
4. Added some additional logging at the end. 